### PR TITLE
Add Dockerfile for wppconnect service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# bots
+# Bots
+
+## wppconnect-serve
+
+This directory contains a small REST service that wraps the [wppconnect](https://github.com/wppconnect-team/wppconnect) library.
+
+### Building the Docker image
+
+```
+docker build -t wppconnect-serve ./wppconnect-serve
+```
+
+### Running the container
+
+```
+docker run -p 3000:3000 wppconnect-serve
+```
+
+The server will start on port 3000 by default.

--- a/wppconnect-serve/.dockerignore
+++ b/wppconnect-serve/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/wppconnect-serve/Dockerfile
+++ b/wppconnect-serve/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:18-alpine
+
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+RUN npm install --production
+
+COPY . .
+
+EXPOSE 3000
+CMD ["npm", "start"]


### PR DESCRIPTION
## Summary
- add Dockerfile and .dockerignore for `wppconnect-serve`
- document Docker build and run steps in README

## Testing
- `npm install --quiet`
- `npm test` *(fails: Error: no test specified)*
- `docker build` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684f2e2f17148323a9d98f51c5c7e53b