### PR TITLE
Refactor server responsibilities into modules

### DIFF
--- a/wppconnect-serve/listeners/messageListener.js
+++ b/wppconnect-serve/listeners/messageListener.js
@@ -1,0 +1,7 @@
+function registerMessageListener(client) {
+  client.onMessage((message) => {
+    console.log('Received message:', message);
+  });
+}
+
+module.exports = { registerMessageListener };

--- a/wppconnect-serve/routes/qrCode.js
+++ b/wppconnect-serve/routes/qrCode.js
@@ -1,0 +1,16 @@
+let lastQrData = null;
+
+function setLastQrData(data) {
+  lastQrData = data;
+}
+
+function registerQrRoute(app) {
+  app.get('/qr-code', (req, res) => {
+    if (!lastQrData) {
+      return res.status(404).json({ error: 'QrCode not generated yet' });
+    }
+    res.json(lastQrData);
+  });
+}
+
+module.exports = { setLastQrData, registerQrRoute };

--- a/wppconnect-serve/routes/sendMessage.js
+++ b/wppconnect-serve/routes/sendMessage.js
@@ -1,0 +1,16 @@
+function registerSendMessageRoute(app, client) {
+  app.post('/send-message', async (req, res) => {
+    const { number, message } = req.body;
+    if (!number || !message) {
+      return res.status(400).json({ error: 'number and message are required' });
+    }
+    try {
+      await client.sendText(`${number}@c.us`, message);
+      res.json({ status: 'sent' });
+    } catch (error) {
+      res.status(500).json({ error: error.toString() });
+    }
+  });
+}
+
+module.exports = { registerSendMessageRoute };

--- a/wppconnect-serve/routes/sessions.js
+++ b/wppconnect-serve/routes/sessions.js
@@ -1,0 +1,20 @@
+const sessions = {};
+
+function registerSession(sessionName) {
+  sessions[sessionName] = { status: 'offline' };
+}
+
+function setSessionStatus(sessionName, status) {
+  if (!sessions[sessionName]) {
+    sessions[sessionName] = {};
+  }
+  sessions[sessionName].status = status;
+}
+
+function registerSessionsRoute(app) {
+  app.get('/sessions', (req, res) => {
+    res.json(sessions);
+  });
+}
+
+module.exports = { registerSession, setSessionStatus, registerSessionsRoute };


### PR DESCRIPTION
## Summary
- Separate QR code handling, message sending, session listing, and message listening into dedicated modules
- Add endpoint to list online sessions
- Initialize message listener to log received messages

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68acf4ded9c8832380df4a7670d23cae