### PR TITLE
Persist WhatsApp session between server restarts

### DIFF
--- a/wppconnect-serve/server.js
+++ b/wppconnect-serve/server.js
@@ -1,11 +1,16 @@
 const wppconnect = require('@wppconnect-team/wppconnect');
 const express = require('express');
+const path = require('path');
 const { setLastQrData, registerQrRoute } = require('./routes/qrCode');
 const { registerSendMessageRoute } = require('./routes/sendMessage');
 const { registerMessageListener } = require('./listeners/messageListener');
 const { registerSession, setSessionStatus, registerSessionsRoute } = require('./routes/sessions');
 
 const sessionName = 'server-session';
+const tokenFolder = path.resolve(__dirname, 'tokens');
+const fileTokenStore = new wppconnect.tokenStore.FileTokenStore({
+  path: tokenFolder,
+});
 
 wppconnect
   .create({
@@ -13,6 +18,9 @@ wppconnect
     catchQR: (base64Qr, asciiQR, attempts, urlQR) => {
       setLastQrData({ base64Qr, asciiQR, attempts, urlQR });
     },
+    folderNameToken: tokenFolder,
+    tokenStore: fileTokenStore,
+    autoClose: 0,
   })
   .then((client) => {
     registerSession(sessionName);


### PR DESCRIPTION
## Summary
- store WPPConnect session tokens in a fixed folder to allow reconnecting after server restarts
- disable autoClose so the session stays alive

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68acf946245c8323a3983a68b4850968